### PR TITLE
MOB-1576 GRPC Build error on x86_64 Android

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,6 +216,11 @@ else()
   set(_gRPC_CORE_NOSTDCXX_FLAGS "")
 endif()
 
+option(GPR_MUSL_LIBC_COMPAT "Build GRPC Libc Compat" OFF)
+if(GPR_MUSL_LIBC_COMPAT)
+  add_definitions(-DGPR_MUSL_LIBC_COMPAT)
+endif()
+
 include(cmake/abseil-cpp.cmake)
 include(cmake/address_sorting.cmake)
 include(cmake/benchmark.cmake)


### PR DESCRIPTION

in crux-lib-deps,
run 'make build_android' ends up building error for grpc/x86_64 because GPR_MUSL_LIBC_COMPAT is not defined in grpc.

Library/Android/sdk/ndk-bundle/toolchains/llvm/prebuilt/darwin-x86_64/sysroot/usr/include/bits/fortify/string.h:62: error: undefined reference to 'memcpy', version 'GLIBC_2.2.5'
