### PR TITLE
MOB-1576 GRPC Build error on x86_64 Android

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,6 +248,11 @@ else()
   set(_gRPC_CORE_NOSTDCXX_FLAGS "")
 endif()
 
+option(GPR_MUSL_LIBC_COMPAT "Build GRPC Libc Compat" OFF)
+if(GPR_MUSL_LIBC_COMPAT)
+  add_definitions(-DGPR_MUSL_LIBC_COMPAT)
+endif()
+
 if (gRPC_XDS_USER_AGENT_IS_CSHARP)
   # The value of the defines needs to contain quotes.
   # See https://github.com/grpc/grpc/blob/fbf32836a418cc84f58786700273b65cb9174e1d/src/core/ext/xds/xds_api.cc#L854

--- a/gRPC-C++.podspec
+++ b/gRPC-C++.podspec
@@ -66,7 +66,7 @@ Pod::Spec.new do |s|
   s.libraries = 'c++'
   s.compiler_flags = '-Wno-comma -Wno-unreachable-code -Wno-shorten-64-to-32'
 
-  s.default_subspecs = 'Interface', 'Implementation'
+  s.default_subspecs = 'Interface', 'Implementation', 'Protobuf'
 
   # Certificates, to be able to establish TLS connections:
   s.resource_bundles = { 'gRPCCertificates-Cpp' => ['etc/roots.pem'] }


### PR DESCRIPTION

in crux-lib-deps,
run 'make build_android' ends up building error for grpc/x86_64 because GPR_MUSL_LIBC_COMPAT is not defined in grpc.

Library/Android/sdk/ndk-bundle/toolchains/llvm/prebuilt/darwin-x86_64/sysroot/usr/include/bits/fortify/string.h:62: error: undefined reference to 'memcpy', version 'GLIBC_2.2.5'.

This is based on crux-v1.40.0 which is based on grpc/grpc release v1.40.0.

crux-lib-deps should be changed accordingly.

