### PR TITLE
[EX-3143] Fix macOS build: use SHELL: prefix for abseil -Xarch_ flags

### DIFF
--- a/cmake/abseil-cpp.cmake
+++ b/cmake/abseil-cpp.cmake
@@ -25,6 +25,21 @@ elseif(gRPC_ABSL_PROVIDER STREQUAL "module")
       # Abseil will be installed along with gRPC for convenience.
       set(ABSL_ENABLE_INSTALL ON)
     endif()
+    # [EX-3143] On Apple/Clang, -Xarch_<arch> <flag> pairs must be passed as a
+    # single shell token to prevent CMake flag deduplication from separating them.
+    # Patch AbseilConfigureCopts.cmake to use the SHELL: prefix before abseil
+    # targets are configured. Fixed upstream in abseil lts_2024_07_22 (PR #1710).
+    if(APPLE AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+      set(_absl_copts_file "${ABSL_ROOT_DIR}/absl/copts/AbseilConfigureCopts.cmake")
+      if(EXISTS "${_absl_copts_file}")
+        file(READ "${_absl_copts_file}" _absl_copts_content)
+        string(REPLACE
+          "list(APPEND ABSL_RANDOM_RANDEN_COPTS \"-Xarch_\${_arch}\" \"\${_flag}\")"
+          "list(APPEND ABSL_RANDOM_RANDEN_COPTS \"SHELL:-Xarch_\${_arch} \${_flag}\")"
+          _absl_copts_content "${_absl_copts_content}")
+        file(WRITE "${_absl_copts_file}" "${_absl_copts_content}")
+      endif()
+    endif()
     add_subdirectory(${ABSL_ROOT_DIR} third_party/abseil-cpp)
   else()
     message(WARNING "gRPC_ABSL_PROVIDER is \"module\" but ABSL_ROOT_DIR is wrong")


### PR DESCRIPTION
## Summary

- Patches `cmake/abseil-cpp.cmake` to fix the `-Xarch_<arch> <flag>` flag handling on Apple/Clang builds
- CMake's flag deduplication logic separates `-Xarch_<arch>` from its argument, causing the flag to be passed without its architecture guard and breaking compilation
- The fix wraps each pair with `SHELL:` prefix (e.g. `SHELL:-Xarch_x86_64 -maes`) so CMake treats them as a single shell token, preventing deduplication from splitting them

## Root cause

From the [CMake docs](https://cmake.org/cmake/help/latest/command/target_compile_options.html#option-de-duplication):
> While beneficial for individual options, the de-duplication step can break up option groups. For example, `-option A -option B` becomes `-option A B`. One may specify a group of options using shell-like quoting along with a `SHELL:` prefix.

Upstream fix: abseil-cpp [PR #1710](https://github.com/abseil/abseil-cpp/pull/1710), landed in `lts_2024_07_22`.

## Jira

[EX-3143](https://safetyculture.atlassian.net/browse/EX-3143)

## Test plan

- [ ] Verify macOS build succeeds after this change
- [ ] Verify Linux/Android builds are unaffected

[EX-3143]: https://safetyculture.atlassian.net/browse/EX-3143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ