### PR TITLE
[MBUGS-2701] Cherry-pick grpc#36921 — guard null endpoint in transport ops

### DIFF
--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -1938,11 +1938,15 @@ static void perform_transport_op_locked(void* stream_op,
   }
 
   if (op->bind_pollset) {
-    grpc_endpoint_add_to_pollset(t->ep, op->bind_pollset);
+    if (t->ep != nullptr) {
+      grpc_endpoint_add_to_pollset(t->ep, op->bind_pollset);
+    }
   }
 
   if (op->bind_pollset_set) {
-    grpc_endpoint_add_to_pollset_set(t->ep, op->bind_pollset_set);
+    if (t->ep != nullptr) {
+      grpc_endpoint_add_to_pollset_set(t->ep, op->bind_pollset_set);
+    }
   }
 
   if (op->send_ping.on_initiate != nullptr || op->send_ping.on_ack != nullptr) {


### PR DESCRIPTION
## Summary

Backports upstream gRPC commit [`f0bbdeab3660`](https://github.com/grpc/grpc/commit/f0bbdeab3660) — *"[chttp2] don't access endpoint in transport ops if it's already been destroyed (#36921)"* — onto `crux-v1.65.x`. First released upstream in **v1.66.0**; absent from the 1.65.x branch our crux build pins.

## The crash ([MBUGS-2701](https://safetyculture.atlassian.net/browse/MBUGS-2701))

iOS `EXC_BAD_ACCESS (KERN_INVALID_ADDRESS)` in `grpc_endpoint_add_to_pollset`, on a gRPC EventEngine `WorkStealingThreadPool` thread (no app frames). [Crashlytics issue](https://console.firebase.google.com/u/0/project/project-8638960581077738091/crashlytics/app/ios:com.safetyculture.iAuditor/issues/c60bf2ffd2e9f17913717bce80d4b31f).

`perform_transport_op_locked` read `t->ep` without a null check and called `grpc_endpoint_add_to_pollset(_set)` on it. After the endpoint is destroyed (`close_transport_locked` sets `t->ep = nullptr`), a later combiner-scheduled transport op carrying `bind_pollset(_set)` dereferences the null endpoint → crash. The sibling `SetPollset`/`SetPollsetSet` paths already guard `ep` this way; `perform_transport_op_locked` was missing it.

## Fix

Wrap both calls in `if (t->ep != nullptr)` — identical to the upstream commit (single file, +6/-2).

## Bisect

| ref | guard |
|---|---|
| v1.65.5 (our base) | ❌ absent — the crash |
| v1.66.0+ | ✅ present (`f0bbdeab3660`) |

Verified by reading `chttp2_transport.cc` at both tags and via commit ancestry.

## Relationship to crux#3912

Defence-in-depth, complementary to [crux#3912](https://github.com/SafetyCulture/crux/pull/3912) (the `mConnectionChannel` `shared_ptr` data-race fix, MBUGS-2701). #3912 removes the dominant *trigger* (the UB that tears the transport down); this guard makes gRPC *tolerate* a null endpoint — the "gRPC-internal teardown variant" #3912 explicitly notes it cannot cover. Recommend landing both.

## Rollout (after merge)

1. Bump `deps/grpc` in `crux-lib-deps` to this commit; `make ios-grpc` (+ `make android`); commit regenerated xcframeworks; release.
2. Bump the crux-lib-deps pin in `crux`; cut a new Crux; `make set-crux` in iAuditor-iOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MBUGS-2701]: https://safetyculture.atlassian.net/browse/MBUGS-2701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ